### PR TITLE
Feat: [공통] get_it을 사용한 의존성 주입 환경 구축 #31

### DIFF
--- a/lib/app/di/app_binding.dart
+++ b/lib/app/di/app_binding.dart
@@ -1,0 +1,15 @@
+final class AppBinder {
+  AppBinder._();
+
+  /// 'Splash' 단계에서 우선적으로 Binding 해야되는 모듈들은
+  /// 아래 메소드에서 처리합
+  static void _initTopPriority() {}
+
+  static void init() {
+    _initTopPriority();
+
+    for (final di in []) {
+      di.init();
+    }
+  }
+}

--- a/lib/app/di/feature_di_interface.dart
+++ b/lib/app/di/feature_di_interface.dart
@@ -1,0 +1,11 @@
+abstract base class FeatureDependencyInjection {
+  void init() {
+    dataSources();
+    repositories();
+    useCases();
+  }
+
+  void dataSources();
+  void repositories();
+  void useCases();
+}

--- a/lib/app/di/locator.dart
+++ b/lib/app/di/locator.dart
@@ -1,0 +1,17 @@
+import 'package:get_it/get_it.dart';
+
+final GetIt locator = GetIt.I;
+
+// 안전하게 등록된 인스턴스를 해제하는 메소드
+void safeUnregister<T extends Object>() {
+  if (locator.isRegistered<T>()) {
+    locator.unregister<T>();
+  }
+}
+
+// 안전하게 Factory 인스턴스를 등록하는 메소드
+void safeRegisterFactory<T extends Object>(FactoryFunc<T> factoryFunc) {
+  if (!locator.isRegistered<T>()) {
+    locator.registerFactory<T>(factoryFunc);
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,55 +7,59 @@ environment:
   sdk: ">=3.0.0 <4.0.0"
 
 dependencies:
-  bloc: ^8.1.2
-  change_app_package_name: ^1.1.0
-  cupertino_icons: ^1.0.2
   flutter:
     sdk: flutter
 
+  # Firebase
   firebase_core: ^2.15.0
   firebase_auth: ^4.7.2
   sign_in_with_apple: ^5.0.0
   google_sign_in: ^6.1.4
   kakao_flutter_sdk_auth: ^1.5.0
   kakao_flutter_sdk_user: ^1.4.1
-  go_router: ^10.0.0
-  intl: ^0.18.1
-  dio: ^5.2.1+1
-  freezed_annotation: ^2.4.1
-  google_maps_flutter: ^2.4.0
-  retrofit: ^4.0.3
-  infinite_scroll_pagination: ^4.0.0
 
   # UI
   cupertino_will_pop_scope: ^1.2.1 #pop scope (스와이프 백 제스쳐 지원)
   fluttertoast: ^8.2.2
   flutter_svg: ^2.0.7
   flutter_easyloading: ^3.0.5
+  cupertino_icons: ^1.0.2
 
   # 상태관리
   flutter_riverpod: ^2.3.6
   riverpod_annotation: ^2.1.1
 
+  # 네트워크
+  retrofit: ^4.0.3
+  dio: ^5.2.1+1
+
+  # DI
+  get_it: ^7.2.0
+
+  # 라우팅
+  go_router: ^10.0.0
+  
+
+  # Utils
+  intl: ^0.18.1
+  freezed_annotation: ^2.4.1
+
+  # 앱 정보
+  change_app_package_name: ^1.1.0
 
 dev_dependencies:
   flutter_test:
     sdk: flutter
   mocktail: ^0.3.0
-  # a tool for running code generators
   build_runner: ^2.4.6
-  # the code generator
   riverpod_generator: ^2.2.3
-  # riverpod_lint makes it easier to work with Riverpod
   riverpod_lint: ^1.3.2
-  # import custom_lint too as riverpod_lint depends on it
   custom_lint: ^0.4.0
-
   flutter_flavorizr: ^2.2.1
-
   flutter_lints: ^2.0.0
   freezed: ^2.4.1
   json_serializable: ^6.7.1
+  retrofit_generator: ^7.0.2 # 네트워크 API Generator
 
 flutter:
   assets:


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description
get_it을 사용하여 의존성 주입 구조를 구축하였습니다.
의존성 주입을 위해 Riverpod의 provider를 사용할 수도 있으나,
목적에 맞게 툴을 분리하는 것이 추후 기능의 의존도를 낮출 수 있을 것이라고 판단하여 get_it을 사용하였습니다.

- app_binding : 바인딩 수행을 위한 클래스
- locator : 특정 인스턴스를 찾거나 해제하기 위함
- feature_di_interface : feature에서 의존성 주입이 필요한 요소들을 정의하기 위한 interface

** pubspec.yaml 파일도 get_it 추가하면서 정리하였습니다 **

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
